### PR TITLE
Fixed bug: loading train and test data was giving "no directory found…

### DIFF
--- a/src/parse_musicnet.py
+++ b/src/parse_musicnet.py
@@ -60,8 +60,8 @@ def main():
     ]
 
     db = pandas.read_csv(src / 'musicnet_metadata.csv')
-    traindir = src / 'musicnet/train_data'
-    testdir = src / 'musicnet/test_data'
+    traindir = src / 'train_data'
+    testdir = src / 'test_data'
 
     for (ensemble, composer) in domains:
         fid_list = db[(db["composer"] == composer) & (db["ensemble"] == ensemble)].id.tolist()


### PR DESCRIPTION
… error"

While using the notebook, program was looking in an incorrect directory for the train data and test data.  Before changes, when !python src/parse_musicnet.py -i musicnet -o musicnet/parsed was run, it would return a "no file found" error because musicnet/musicnet/test_data does not exist.  The second "musicnet/" in the path was redundant, so I eliminated it from the parse_musicnet.py script.